### PR TITLE
Fix edited replies not updating on other screens via socket

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -17,7 +17,6 @@ type Props = {
   message: NonNullable<MessageWithUser>;
   depth: number;
   childrenMap: Map<string, MessageWithUser[]>;
-  structureVersion: number;
   pageLoadTime: Date;
   cloudName?: string;
   handleReadMessage: (message: MessageWithUser) => void;
@@ -71,7 +70,6 @@ function MessageComponent({
   message,
   depth,
   childrenMap,
-  structureVersion,
   pageLoadTime,
   cloudName,
   handleReadMessage,
@@ -106,7 +104,7 @@ function MessageComponent({
     setShowMessageForm(false);
   };
 
-  const childMessages = childrenMap.get(message.id) ?? [];
+  const childMessages = childrenMap.get(message.id)?.slice() ?? [];
 
   if (!user) return null;
 
@@ -232,8 +230,8 @@ function MessageComponent({
                   message={message}
                   depth={depth + 1}
                   childrenMap={childrenMap}
-                  structureVersion={structureVersion}
                   pageLoadTime={pageLoadTime}
+                  cloudName={cloudName}
                   handleReadMessage={handleReadMessage}
                 />
               </div>
@@ -245,12 +243,11 @@ function MessageComponent({
 
 export default memo(MessageComponent, (prev, next) => {
   if (prev.message !== next.message) return false;
-  if (prev.structureVersion !== next.structureVersion) return false;
   if (prev.pageLoadTime !== next.pageLoadTime) return false;
 
   const prevChildren = prev.childrenMap.get(prev.message.id);
   const nextChildren = next.childrenMap.get(next.message.id);
-  if (prevChildren === nextChildren) return true;
+  if (!prevChildren && !nextChildren) return true;
   if (!prevChildren || !nextChildren) return false;
   if (prevChildren.length !== nextChildren.length) return false;
   return prevChildren.every((child, i) => child === nextChildren[i]);

--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -243,8 +243,15 @@ function MessageComponent({
   );
 }
 
-export default memo(MessageComponent, (prev, next) =>
-  prev.message === next.message &&
-  prev.structureVersion === next.structureVersion &&
-  prev.pageLoadTime === next.pageLoadTime
-);
+export default memo(MessageComponent, (prev, next) => {
+  if (prev.message !== next.message) return false;
+  if (prev.structureVersion !== next.structureVersion) return false;
+  if (prev.pageLoadTime !== next.pageLoadTime) return false;
+
+  const prevChildren = prev.childrenMap.get(prev.message.id);
+  const nextChildren = next.childrenMap.get(next.message.id);
+  if (prevChildren === nextChildren) return true;
+  if (!prevChildren || !nextChildren) return false;
+  if (prevChildren.length !== nextChildren.length) return false;
+  return prevChildren.every((child, i) => child === nextChildren[i]);
+});

--- a/app/routes/posts/$postId.tsx
+++ b/app/routes/posts/$postId.tsx
@@ -422,7 +422,6 @@ export default function PostPage() {
                   message={message}
                   depth={0}
                   childrenMap={childrenMap}
-                  structureVersion={messageDisplay.length}
                   key={message.id}
                   pageLoadTime={pageLoadTime}
                   cloudName={data.cloudinaryCloudName}


### PR DESCRIPTION
The memo comparator in Message.tsx omitted childrenMap, so when a nested
reply was edited the parent component skipped re-rendering (its own message
prop and structureVersion were unchanged), and the updated childrenMap was
never passed down to the reply.

Now the comparator also checks whether the immediate children array for this
message changed (element-by-element reference comparison). Because childrenMap
is rebuilt from messageDisplay on every edit, each MessageComponent at every
nesting depth will correctly detect when one of its direct children was edited
and re-render to propagate the new text.

https://claude.ai/code/session_0185fSuCYLgmQwzq1iAf2CKy