### PR TITLE
Refactor socket listeners and improve React memoization

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -104,7 +104,7 @@ function MessageComponent({
     setShowMessageForm(false);
   };
 
-  const childMessages = childrenMap.get(message.id)?.slice() ?? [];
+  const childMessages = childrenMap.get(message.id) ?? [];
 
   if (!user) return null;
 
@@ -244,14 +244,17 @@ function MessageComponent({
 function hasDescendantChanged(
   id: string,
   prevMap: Map<string, MessageWithUser[]>,
-  nextMap: Map<string, MessageWithUser[]>
+  nextMap: Map<string, MessageWithUser[]>,
+  visited: Set<string> = new Set()
 ): boolean {
+  if (visited.has(id)) return false;
+  visited.add(id);
   const prevChildren = prevMap.get(id) ?? [];
   const nextChildren = nextMap.get(id) ?? [];
   if (prevChildren.length !== nextChildren.length) return true;
   for (let i = 0; i < prevChildren.length; i++) {
     if (prevChildren[i] !== nextChildren[i]) return true;
-    if (prevChildren[i] && hasDescendantChanged(prevChildren[i].id, prevMap, nextMap)) return true;
+    if (prevChildren[i] && hasDescendantChanged(prevChildren[i].id, prevMap, nextMap, visited)) return true;
   }
   return false;
 }
@@ -259,5 +262,6 @@ function hasDescendantChanged(
 export default memo(MessageComponent, (prev, next) => {
   if (prev.message !== next.message) return false;
   if (prev.pageLoadTime !== next.pageLoadTime) return false;
+  if (prev.childrenMap === next.childrenMap) return true;
   return !hasDescendantChanged(prev.message.id, prev.childrenMap, next.childrenMap);
 });

--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -253,8 +253,10 @@ function hasDescendantChanged(
   const nextChildren = nextMap.get(id) ?? [];
   if (prevChildren.length !== nextChildren.length) return true;
   for (let i = 0; i < prevChildren.length; i++) {
-    if (prevChildren[i] !== nextChildren[i]) return true;
-    if (prevChildren[i] && hasDescendantChanged(prevChildren[i].id, prevMap, nextMap, visited)) return true;
+    const prevChild = prevChildren[i];
+    const nextChild = nextChildren[i];
+    if (prevChild !== nextChild) return true;
+    if (prevChild && hasDescendantChanged(prevChild.id, prevMap, nextMap, visited)) return true;
   }
   return false;
 }

--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -241,14 +241,23 @@ function MessageComponent({
   );
 }
 
+function hasDescendantChanged(
+  id: string,
+  prevMap: Map<string, MessageWithUser[]>,
+  nextMap: Map<string, MessageWithUser[]>
+): boolean {
+  const prevChildren = prevMap.get(id) ?? [];
+  const nextChildren = nextMap.get(id) ?? [];
+  if (prevChildren.length !== nextChildren.length) return true;
+  for (let i = 0; i < prevChildren.length; i++) {
+    if (prevChildren[i] !== nextChildren[i]) return true;
+    if (prevChildren[i] && hasDescendantChanged(prevChildren[i].id, prevMap, nextMap)) return true;
+  }
+  return false;
+}
+
 export default memo(MessageComponent, (prev, next) => {
   if (prev.message !== next.message) return false;
   if (prev.pageLoadTime !== next.pageLoadTime) return false;
-
-  const prevChildren = prev.childrenMap.get(prev.message.id);
-  const nextChildren = next.childrenMap.get(next.message.id);
-  if (!prevChildren && !nextChildren) return true;
-  if (!prevChildren || !nextChildren) return false;
-  if (prevChildren.length !== nextChildren.length) return false;
-  return prevChildren.every((child, i) => child === nextChildren[i]);
+  return !hasDescendantChanged(prev.message.id, prev.childrenMap, next.childrenMap);
 });

--- a/app/routes/posts/$postId.tsx
+++ b/app/routes/posts/$postId.tsx
@@ -208,9 +208,9 @@ export default function PostPage() {
   let data = useLoaderData() as LoaderData;
   const socket = useSocket();
   const postId = data.post?.id;
-  const [listOfMessages, setListOfMessages] =
-    useState<MessageWithUser[]>(data.post!.messages) ||
-    ([] as MessageWithUser[]);
+  const [listOfMessages, setListOfMessages] = useState<MessageWithUser[]>(
+    data.post?.messages ?? []
+  );
   const [syncTimer, setSyncTimer] = useState<number | null>(INITIAL_SYNC_TIMER);
   const [pageLoadTime, setPageLoadTime] = useState(new Date());
   const [unreadMessages, setUnreadMessages] = useState<MessageWithUser[]>([]);
@@ -269,7 +269,7 @@ export default function PostPage() {
     const handleReconnect = () => socket.emit("joinPage", postId);
     socket.io.on("reconnect", handleReconnect);
 
-    socket.on("messagePosted", (newMessage: MessageWithUser) => {
+    const onMessagePosted = (newMessage: MessageWithUser) => {
       if (!newMessage) return;
       // Use ref so this handler never needs listOfMessages in the effect deps,
       // avoiding full listener teardown on every received message.
@@ -288,9 +288,9 @@ export default function PostPage() {
         return messages;
       });
       setListOfMessages((messages) => [newMessage, ...messages]);
-    });
+    };
 
-    socket.on("messageEdited", (editedMessage: MessageWithUser) => {
+    const onMessageEdited = (editedMessage: MessageWithUser) => {
       if (!editedMessage) return;
       setListOfMessages((messages) => {
         const idx = messages.findIndex(m => m?.id === editedMessage.id);
@@ -301,9 +301,9 @@ export default function PostPage() {
         updated[idx] = { ...existing, text: editedMessage.text };
         return updated;
       });
-    });
+    };
 
-    socket.on("likePosted", (newLike: LikeWithUser) => {
+    const onLikePosted = (newLike: LikeWithUser) => {
       if (!newLike) return;
       setListOfMessages((messages) => {
         const idx = messages.findIndex(m => m?.id === newLike.messageId);
@@ -315,9 +315,9 @@ export default function PostPage() {
         updated[idx] = { ...existing, likes: [...existing.likes, newLike] };
         return updated;
       });
-    });
+    };
 
-    socket.on("unlikePosted", (newUnlike: LikeWithUser) => {
+    const onUnlikePosted = (newUnlike: LikeWithUser) => {
       if (!newUnlike) return;
       setListOfMessages((messages) => {
         const idx = messages.findIndex(m => m?.id === newUnlike.messageId);
@@ -328,19 +328,29 @@ export default function PostPage() {
         updated[idx] = { ...existing, likes: existing.likes.filter(l => l.id !== newUnlike.id) };
         return updated;
       });
-    });
+    };
 
     // Use functional updater so syncTimer doesn't need to be in the effect deps.
-    socket.on("outOfSync", () => {
+    const onOutOfSync = () => {
       setSyncTimer((current) => {
         if (current === INITIAL_SYNC_TIMER) return SECOND_SYNC_TIMER;
         if (current === SECOND_SYNC_TIMER) return THIRD_SYNC_TIMER;
         return null;
       });
-    });
+    };
+
+    socket.on("messagePosted", onMessagePosted);
+    socket.on("messageEdited", onMessageEdited);
+    socket.on("likePosted", onLikePosted);
+    socket.on("unlikePosted", onUnlikePosted);
+    socket.on("outOfSync", onOutOfSync);
 
     return () => {
-      socket.removeAllListeners();
+      socket.off("messagePosted", onMessagePosted);
+      socket.off("messageEdited", onMessageEdited);
+      socket.off("likePosted", onLikePosted);
+      socket.off("unlikePosted", onUnlikePosted);
+      socket.off("outOfSync", onOutOfSync);
       socket.io.off("reconnect", handleReconnect);
       socket.emit("leavePage", postId);
     };
@@ -354,7 +364,7 @@ export default function PostPage() {
     // (e.g. messages that were rejected or deleted before the next loader refresh).
     setListOfMessages(serverMessages);
     setUnreadMessages((prev) => prev.filter((m) => m?.id && serverIds.has(m.id)));
-  }, [data, setListOfMessages]);
+  }, [data]);
 
   const messageDisplay =
     listOfMessages.length > 0 ? listOfMessages : data.post?.messages ?? [];

--- a/app/routes/posts/$postId.tsx
+++ b/app/routes/posts/$postId.tsx
@@ -207,6 +207,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
 export default function PostPage() {
   let data = useLoaderData() as LoaderData;
   const socket = useSocket();
+  const postId = data.post?.id;
   const [listOfMessages, setListOfMessages] =
     useState<MessageWithUser[]>(data.post!.messages) ||
     ([] as MessageWithUser[]);
@@ -261,15 +262,11 @@ export default function PostPage() {
   };
 
   useEffect(() => {
-    if (!socket) return;
+    if (!socket || !postId) return;
 
-    if (data.post) {
-      socket.emit("joinPage", data.post.id);
-    }
+    socket.emit("joinPage", postId);
 
-    const handleReconnect = () => {
-      if (data.post) socket.emit("joinPage", data.post.id);
-    };
+    const handleReconnect = () => socket.emit("joinPage", postId);
     socket.io.on("reconnect", handleReconnect);
 
     socket.on("messagePosted", (newMessage: MessageWithUser) => {
@@ -313,6 +310,7 @@ export default function PostPage() {
         if (idx === -1) return messages;
         const existing = messages[idx];
         if (!existing) return messages;
+        if (existing.likes.some(l => l.id === newLike.id)) return messages;
         const updated = [...messages];
         updated[idx] = { ...existing, likes: [...existing.likes, newLike] };
         return updated;
@@ -344,9 +342,9 @@ export default function PostPage() {
     return () => {
       socket.removeAllListeners();
       socket.io.off("reconnect", handleReconnect);
-      socket.emit("leavePage", data.post?.id);
+      socket.emit("leavePage", postId);
     };
-  }, [socket, data, setListOfMessages]);
+  }, [socket, postId]);
 
   useEffect(() => {
     if (!data.post) return;
@@ -403,9 +401,9 @@ export default function PostPage() {
             viewBox="0 0 24 24"
           >
             <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
               d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>


### PR DESCRIPTION
## Summary
This PR refactors socket event handling to improve cleanup and dependency management, while also enhancing the memoization logic for message components to properly track descendant changes.

## Key Changes

### Socket Event Handling Refactoring (`app/routes/posts/$postId.tsx`)
- **Extracted `postId` state**: Added explicit `postId` variable to avoid repeated property access and improve clarity
- **Fixed useState initialization**: Changed from incorrect `||` operator to proper nullish coalescing (`??`) for default empty array
- **Refactored socket listeners**: Converted inline socket event handlers to named function declarations (`onMessagePosted`, `onMessageEdited`, `onLikePosted`, `onUnlikePosted`, `onOutOfSync`)
- **Improved cleanup**: Replaced `removeAllListeners()` with specific `socket.off()` calls for each event, preventing accidental removal of other listeners
- **Optimized dependencies**: Reduced effect dependencies from `[socket, data, setListOfMessages]` to `[socket, postId]`, eliminating unnecessary re-subscriptions
- **Added duplicate like prevention**: Added check to prevent duplicate likes from being added to messages
- **Fixed JSX attributes**: Converted hyphenated SVG attributes (`stroke-linecap`, `stroke-linejoin`, `stroke-width`) to camelCase React format

### Message Component Memoization (`app/components/Message.tsx`)
- **Removed unnecessary slice()**: Simplified `childrenMap.get()` call by removing redundant `.slice()` operation
- **Implemented recursive descendant tracking**: Added `hasDescendantChanged()` helper function to properly detect changes in nested message trees, preventing unnecessary re-renders while ensuring updates propagate correctly
- **Enhanced memo comparison**: Updated the memoization logic to check the entire descendant tree rather than just direct children, improving performance for deeply nested message threads

## Notable Implementation Details
- The socket listener refactoring ensures proper cleanup on component unmount and socket reconnection, preventing memory leaks and duplicate event handlers
- The new `hasDescendantChanged()` function uses a visited set to prevent infinite loops when checking circular references in the message tree
- The memoization improvement maintains referential equality checks while properly detecting structural changes in nested message hierarchies

https://claude.ai/code/session_01JmuTDrvhVG4f2xECttoUDW