### PR TITLE
Add disconnect notice and missed-message catch-up

### DIFF
--- a/app/routes/posts/$postId.tsx
+++ b/app/routes/posts/$postId.tsx
@@ -285,8 +285,14 @@ export default function PostPage() {
     const handleConnect = () => setConnectionStatus("connected");
     const handleDisconnect = () => setConnectionStatus("disconnected");
     const handleReconnectAttempt = () => setConnectionStatus("reconnecting");
+    // connect_error fires when the socket can't establish a connection in the
+    // first place (e.g. the page loaded over HTTP but the WS never came up).
+    // Without this, a cold failure would leave the optimistic "connected"
+    // status in place and show no notice.
+    const handleConnectError = () => setConnectionStatus("reconnecting");
     socket.on("connect", handleConnect);
     socket.on("disconnect", handleDisconnect);
+    socket.on("connect_error", handleConnectError);
     socket.io.on("reconnect_attempt", handleReconnectAttempt);
     socket.io.on("reconnect", handleConnect);
 
@@ -373,6 +379,7 @@ export default function PostPage() {
       socket.io.off("reconnect", handleReconnect);
       socket.off("connect", handleConnect);
       socket.off("disconnect", handleDisconnect);
+      socket.off("connect_error", handleConnectError);
       socket.io.off("reconnect_attempt", handleReconnectAttempt);
       socket.io.off("reconnect", handleConnect);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
@@ -428,7 +435,7 @@ export default function PostPage() {
       <MessageForm id={data.post.id} />
       {connectionStatus !== "connected" && (
         <div className="alert alert-warning mt-4 justify-start">
-          <span className="loading loading-spinner loading-sm" />
+          <span className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
           <span>You're disconnected — trying to reconnect…</span>
         </div>
       )}

--- a/app/routes/posts/$postId.tsx
+++ b/app/routes/posts/$postId.tsx
@@ -18,9 +18,7 @@ import { useSocket } from "~/context";
 import type { Like, LikeWithUser } from "~/models/like.server";
 import { deleteLike, findLikeByUserAndMessage , createLike } from "~/models/like.server";
 
-const INITIAL_SYNC_TIMER = 60000;
-const SECOND_SYNC_TIMER = 10000;
-const THIRD_SYNC_TIMER = 5000;
+type ConnectionStatus = "connected" | "disconnected" | "reconnecting";
 
 type LoaderData = {
   post: PostWithMessages;
@@ -211,7 +209,8 @@ export default function PostPage() {
   const [listOfMessages, setListOfMessages] = useState<MessageWithUser[]>(
     data.post?.messages ?? []
   );
-  const [syncTimer, setSyncTimer] = useState<number | null>(INITIAL_SYNC_TIMER);
+  const [connectionStatus, setConnectionStatus] =
+    useState<ConnectionStatus>("connected");
   const [pageLoadTime, setPageLoadTime] = useState(new Date());
   const [unreadMessages, setUnreadMessages] = useState<MessageWithUser[]>([]);
 
@@ -266,8 +265,39 @@ export default function PostPage() {
 
     socket.emit("joinPage", postId);
 
-    const handleReconnect = () => socket.emit("joinPage", postId);
+    // Ask the server to replay any messages newer than the newest one we already
+    // have, so we recover anything broadcast while we were disconnected. The list
+    // is ordered createdAt desc, so index 0 is the newest message we know about.
+    const requestCatchUp = () => {
+      const newest = listOfMessagesRef.current[0]?.createdAt;
+      socket.emit("catchUp", {
+        postId,
+        lastMessageTimestamp: newest ?? null,
+      });
+    };
+
+    const handleReconnect = () => {
+      socket.emit("joinPage", postId);
+      requestCatchUp();
+    };
     socket.io.on("reconnect", handleReconnect);
+
+    const handleConnect = () => setConnectionStatus("connected");
+    const handleDisconnect = () => setConnectionStatus("disconnected");
+    const handleReconnectAttempt = () => setConnectionStatus("reconnecting");
+    socket.on("connect", handleConnect);
+    socket.on("disconnect", handleDisconnect);
+    socket.io.on("reconnect_attempt", handleReconnectAttempt);
+    socket.io.on("reconnect", handleConnect);
+
+    // Catch up when the tab is refocused even if the socket never fully dropped —
+    // covers broadcasts missed during sleep without a clean disconnect.
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible" && socket.connected) {
+        requestCatchUp();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     const onMessagePosted = (newMessage: MessageWithUser) => {
       if (!newMessage) return;
@@ -330,28 +360,22 @@ export default function PostPage() {
       });
     };
 
-    // Use functional updater so syncTimer doesn't need to be in the effect deps.
-    const onOutOfSync = () => {
-      setSyncTimer((current) => {
-        if (current === INITIAL_SYNC_TIMER) return SECOND_SYNC_TIMER;
-        if (current === SECOND_SYNC_TIMER) return THIRD_SYNC_TIMER;
-        return null;
-      });
-    };
-
     socket.on("messagePosted", onMessagePosted);
     socket.on("messageEdited", onMessageEdited);
     socket.on("likePosted", onLikePosted);
     socket.on("unlikePosted", onUnlikePosted);
-    socket.on("outOfSync", onOutOfSync);
 
     return () => {
       socket.off("messagePosted", onMessagePosted);
       socket.off("messageEdited", onMessageEdited);
       socket.off("likePosted", onLikePosted);
       socket.off("unlikePosted", onUnlikePosted);
-      socket.off("outOfSync", onOutOfSync);
       socket.io.off("reconnect", handleReconnect);
+      socket.off("connect", handleConnect);
+      socket.off("disconnect", handleDisconnect);
+      socket.io.off("reconnect_attempt", handleReconnectAttempt);
+      socket.io.off("reconnect", handleConnect);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       socket.emit("leavePage", postId);
     };
   }, [socket, postId]);
@@ -402,22 +426,10 @@ export default function PostPage() {
       </aside>
       <img src={data.post.gif} alt={data.post.title} className="mb-4" />
       <MessageForm id={data.post.id} />
-      {!syncTimer && (
-        <div className="alert alert-error mt-4 justify-start">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-6 w-6 flex-shrink-0 stroke-current"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-          <span>You have lost your connection. Please refresh the page.</span>
+      {connectionStatus !== "connected" && (
+        <div className="alert alert-warning mt-4 justify-start">
+          <span className="loading loading-spinner loading-sm" />
+          <span>You're disconnected — trying to reconnect…</span>
         </div>
       )}
       <div className="pt-8">

--- a/server.ts
+++ b/server.ts
@@ -33,14 +33,34 @@ io.on("connection", (socket) => {
     socket.leave(postId);
   });
 
-  socket.on("ping", async ({ numberOfMessagesInList, postId }) => {
-    const numberOfActualMessages = await prisma.message.count({
+  socket.on("catchUp", async ({ postId, lastMessageTimestamp }) => {
+    if (!postId) return;
+
+    const messages = await prisma.message.findMany({
       where: {
         postId,
+        // gte (not gt) so a message sharing the exact timestamp of our newest
+        // known message isn't skipped; the client dedups by id anyway.
+        ...(lastMessageTimestamp
+          ? { createdAt: { gte: new Date(lastMessageTimestamp) } }
+          : {}),
+      },
+      // Ascending so each prepended message ends up in the correct (desc) order
+      // on the client, which prepends every "messagePosted" it receives.
+      orderBy: { createdAt: "asc" },
+      include: {
+        user: true,
+        likes: {
+          include: {
+            user: true,
+          },
+        },
       },
     });
-    if (numberOfActualMessages !== numberOfMessagesInList)
-      socket.emit("outOfSync", true);
+
+    for (const message of messages) {
+      socket.emit("messagePosted", message);
+    }
   });
 
   socket.on("messagePosted", async (message: Message) => {


### PR DESCRIPTION
Closing a laptop disconnected the socket; on reconnect the client
re-joined the post room but never re-fetched messages broadcast while it
was away, so they were permanently missing. The only "lost connection"
UI was dead code driven by a ping the client never emitted.

- server: add a catchUp handler that replays messages newer than the
  client's latest as messagePosted events (reuses existing dedup/unread
  handling); remove the unused ping/outOfSync handler
- post page: track real Socket.io connection state and show a
  "disconnected — reconnecting" banner; request catch-up on reconnect
  and on tab refocus; remove the dead syncTimer/outOfSync code

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011TLxU1wMwgbYoR8CgYZRcH