### PR TITLE
Optimize message rendering and fix like synchronization

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -250,7 +250,7 @@ function MessageComponent({
                 pageLoadTime={pageLoadTime}
                 cloudName={cloudName}
                 handleReadMessage={handleReadMessage}
-                wrapperClassName="pl-1"
+                wrapperClassName="ml-1"
                 key={message!.id}
               />
             )

--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import parse from "html-react-parser";
+import type { CSSProperties } from "react";
 import { memo, useEffect, useState } from "react";
 import ReactTimeAgo from "react-time-ago";
 import { useBabblesContext } from "~/babblesContext";
@@ -20,7 +21,23 @@ type Props = {
   pageLoadTime: Date;
   cloudName?: string;
   handleReadMessage: (message: MessageWithUser) => void;
+  // Extra classes for the root wrapper. Used by parents to push nested-reply
+  // indentation onto the child's own root, avoiding an extra wrapper div per
+  // reply. Constant per render position, so it is safe to omit from the memo
+  // comparator below.
+  wrapperClassName?: string;
 };
+
+// Let the browser skip layout + paint for off-screen top-level comments while
+// keeping them in the DOM (find-in-page, anchor links, and scroll all keep
+// working). The intrinsic size is only a scrollbar estimate, not a layout
+// constraint on visible comments. Module-level constant so the object reference
+// is stable across renders.
+// Cast because containIntrinsicSize isn't in this csstype version's typings yet.
+const TOP_LEVEL_VISIBILITY_STYLE = {
+  contentVisibility: "auto",
+  containIntrinsicSize: "auto 320px",
+} as CSSProperties;
 
 function getAvatarCloudinaryId(url: string | null) {
   if (!url) return null;
@@ -73,6 +90,7 @@ function MessageComponent({
   pageLoadTime,
   cloudName,
   handleReadMessage,
+  wrapperClassName,
 }: Props) {
   const newerThanInitialLoad = new Date(message.createdAt) > pageLoadTime;
   const [showMessageForm, setShowMessageForm] = useState(false);
@@ -122,6 +140,7 @@ function MessageComponent({
   return (
     <div id={`message-${message.id}`}
       className={clsx(
+        wrapperClassName,
         borderTheme,
         "border-l-4",
         "lg:border-l-8",
@@ -130,6 +149,7 @@ function MessageComponent({
         hasNotBeenViewed ? ["bg-slate-300", "dark:bg-primary"] : "",
         "duration-500"
       )}
+      style={depth === 0 ? TOP_LEVEL_VISIBILITY_STYLE : undefined}
       onMouseOver={handleMouseover}
     >
       <div className="border-b border-secondary px-4 pb-4">
@@ -162,79 +182,77 @@ function MessageComponent({
             </span>
           </div>
         </div>
-        <div>
-          <div className="my-6 break-words">
-            {parse(formattedMessage, replaceOptions)}
-          </div>
-          <div className="">
-            {imagesToDisplay.map((image) => (
-              <ImagePreview
-                image={image}
-                key={image}
-                showOnInitialLoad={newerThanInitialLoad}
-              />
-            ))}
-          </div>
-          {twitterId && (
-            <TwitterEmbed
-              twitterId={twitterId}
-              showOnInitialLoad={newerThanInitialLoad}
-            />
-          )}
-          {threadsUrl && (
-            <ThreadsEmbed
-              threadsUrl={threadsUrl}
-              showOnInitialLoad={newerThanInitialLoad}
-            />
-          )}
-          <div className="mt-4 flex gap-0.5">
-            {depth < 8 && (
-              <button
-                onClick={toggleForm}
-                className="btn btn-secondary btn-sm flex-none"
-                disabled={showEditForm}
-              >
-                Reply
-              </button>
-            )}
-            {isWrittenByCurrentUser && (
-              <button
-                onClick={toggleEditForm}
-                className="btn btn-secondary btn-sm flex-none"
-                disabled={showMessageForm && !showEditForm}
-              >
-                Edit
-              </button>
-            )}
-            <LikeButton message={message} emoji="👍" />
-            <LikeButton message={message} emoji="👎" />
-          </div>
-
-          {message && showMessageForm && (
-            <MessageForm
-              id={message.postId}
-              parentId={message.id}
-              toggleForm={resetButtons}
-              existingMessage={showEditForm ? message : undefined}
-            />
-          )}
+        <div className="my-6 break-words">
+          {parse(formattedMessage, replaceOptions)}
         </div>
+        <div className="">
+          {imagesToDisplay.map((image) => (
+            <ImagePreview
+              image={image}
+              key={image}
+              showOnInitialLoad={newerThanInitialLoad}
+            />
+          ))}
+        </div>
+        {twitterId && (
+          <TwitterEmbed
+            twitterId={twitterId}
+            showOnInitialLoad={newerThanInitialLoad}
+          />
+        )}
+        {threadsUrl && (
+          <ThreadsEmbed
+            threadsUrl={threadsUrl}
+            showOnInitialLoad={newerThanInitialLoad}
+          />
+        )}
+        <div className="mt-4 flex gap-0.5">
+          {depth < 8 && (
+            <button
+              onClick={toggleForm}
+              className="btn btn-secondary btn-sm flex-none"
+              disabled={showEditForm}
+            >
+              Reply
+            </button>
+          )}
+          {isWrittenByCurrentUser && (
+            <button
+              onClick={toggleEditForm}
+              className="btn btn-secondary btn-sm flex-none"
+              disabled={showMessageForm && !showEditForm}
+            >
+              Edit
+            </button>
+          )}
+          <LikeButton message={message} emoji="👍" />
+          <LikeButton message={message} emoji="👎" />
+        </div>
+
+        {message && showMessageForm && (
+          <MessageForm
+            id={message.postId}
+            parentId={message.id}
+            toggleForm={resetButtons}
+            existingMessage={showEditForm ? message : undefined}
+          />
+        )}
       </div>
       {childMessages &&
         childMessages.length > 0 &&
         childMessages.map(
           (message) =>
             message && (
-              <div className={clsx("pl-1")} key={message!.id}>
-                <MessageComponent
-                  message={message}
-                  depth={depth + 1}
-                  childrenMap={childrenMap}
-                  pageLoadTime={pageLoadTime}
-                  cloudName={cloudName}
-                  handleReadMessage={handleReadMessage}
-                />
-              </div>
+              <MessageComponent
+                message={message}
+                depth={depth + 1}
+                childrenMap={childrenMap}
+                pageLoadTime={pageLoadTime}
+                cloudName={cloudName}
+                handleReadMessage={handleReadMessage}
+                wrapperClassName="pl-1"
+                key={message!.id}
+              />
             )
         )}
     </div>

--- a/app/routes/posts/$postId.tsx
+++ b/app/routes/posts/$postId.tsx
@@ -378,7 +378,7 @@ export default function PostPage() {
     }) => {
       if (incomingPostId !== postId) return;
       if (!likes) return;
-      const likesByMessage = new Map<string, LikeWithUser[]>();
+      const likesByMessage = new Map<string, NonNullable<LikeWithUser>[]>();
       for (const like of likes) {
         if (!like) continue;
         const existing = likesByMessage.get(like.messageId) ?? [];

--- a/app/routes/posts/$postId.tsx
+++ b/app/routes/posts/$postId.tsx
@@ -366,16 +366,43 @@ export default function PostPage() {
       });
     };
 
+    // Authoritative like reconciliation sent by the server in response to
+    // catchUp. Replaces every message's likes from the full set so we recover
+    // likes/unlikes (on any message, old or new) missed while disconnected.
+    const onLikesSync = ({
+      postId: incomingPostId,
+      likes,
+    }: {
+      postId: string;
+      likes: LikeWithUser[];
+    }) => {
+      if (incomingPostId !== postId) return;
+      const likesByMessage = new Map<string, LikeWithUser[]>();
+      for (const like of likes) {
+        if (!like) continue;
+        const existing = likesByMessage.get(like.messageId) ?? [];
+        existing.push(like);
+        likesByMessage.set(like.messageId, existing);
+      }
+      setListOfMessages((messages) =>
+        messages.map((m) =>
+          m ? { ...m, likes: likesByMessage.get(m.id) ?? [] } : m
+        )
+      );
+    };
+
     socket.on("messagePosted", onMessagePosted);
     socket.on("messageEdited", onMessageEdited);
     socket.on("likePosted", onLikePosted);
     socket.on("unlikePosted", onUnlikePosted);
+    socket.on("likesSync", onLikesSync);
 
     return () => {
       socket.off("messagePosted", onMessagePosted);
       socket.off("messageEdited", onMessageEdited);
       socket.off("likePosted", onLikePosted);
       socket.off("unlikePosted", onUnlikePosted);
+      socket.off("likesSync", onLikesSync);
       socket.io.off("reconnect", handleReconnect);
       socket.off("connect", handleConnect);
       socket.off("disconnect", handleDisconnect);

--- a/app/routes/posts/$postId.tsx
+++ b/app/routes/posts/$postId.tsx
@@ -377,6 +377,7 @@ export default function PostPage() {
       likes: LikeWithUser[];
     }) => {
       if (incomingPostId !== postId) return;
+      if (!likes) return;
       const likesByMessage = new Map<string, LikeWithUser[]>();
       for (const like of likes) {
         if (!like) continue;
@@ -385,9 +386,18 @@ export default function PostPage() {
         likesByMessage.set(like.messageId, existing);
       }
       setListOfMessages((messages) =>
-        messages.map((m) =>
-          m ? { ...m, likes: likesByMessage.get(m.id) ?? [] } : m
-        )
+        messages.map((m) => {
+          if (!m) return m;
+          const nextLikes = likesByMessage.get(m.id) ?? [];
+          // Preserve the existing reference when the like set is unchanged so
+          // the memoized MessageComponents don't all re-render on every
+          // reconnect/refocus (the comparator keys off message identity).
+          if (m.likes.length === nextLikes.length) {
+            const nextIds = new Set(nextLikes.map((l) => l.id));
+            if (m.likes.every((l) => nextIds.has(l.id))) return m;
+          }
+          return { ...m, likes: nextLikes };
+        })
       );
     };
 

--- a/server.ts
+++ b/server.ts
@@ -61,6 +61,17 @@ io.on("connection", (socket) => {
     for (const message of messages) {
       socket.emit("messagePosted", message);
     }
+
+    // Likes have no timestamp and unlikes are row deletes, so missed like
+    // activity can't be replayed incrementally the way messages are. Instead we
+    // send the authoritative set of all likes for the post and let the client
+    // reconcile, which recovers both likes added to old messages and unlikes
+    // that happened while this client was disconnected.
+    const likes = await prisma.like.findMany({
+      where: { message: { postId } },
+      include: { user: true },
+    });
+    socket.emit("likesSync", { postId, likes });
   });
 
   socket.on("messagePosted", async (message: Message) => {


### PR DESCRIPTION
## Summary
This PR improves performance of the message thread rendering and fixes a bug where likes could be missed when clients reconnect. It includes DOM optimization for off-screen messages and refactors the nested reply indentation approach.

## Key Changes

- **Performance optimization for off-screen messages**: Added `contentVisibility: auto` and `containIntrinsicSize` CSS properties to top-level comments, allowing the browser to skip layout and paint for messages outside the viewport while keeping them in the DOM for find-in-page and anchor links.

- **Simplified nested reply indentation**: Removed wrapper divs around child messages and instead pass `wrapperClassName="ml-1"` directly to nested `MessageComponent` instances. This reduces DOM nesting and allows parents to control child indentation without extra wrapper elements.

- **Fixed like synchronization on reconnect**: Added a new `likesSync` socket event that sends the authoritative set of all likes for a post when a client connects or reconnects. The client reconciles this against its local state, recovering both likes added to old messages and unlikes that occurred while disconnected.

- **Improved like state preservation**: The `onLikesSync` handler preserves message object references when the like set is unchanged, preventing unnecessary re-renders of memoized `MessageComponent` instances on every reconnect/refocus.

- **Refactored message content layout**: Removed an unnecessary wrapper div around message content (text, images, embeds, and buttons), flattening the DOM structure.

## Implementation Details

- The `TOP_LEVEL_VISIBILITY_STYLE` constant is module-level to maintain stable object reference across renders
- The `wrapperClassName` prop is intentionally omitted from the memo comparator since it's constant per render position
- Like reconciliation uses a Map for efficient lookup and only updates message state when the like set actually changes

https://claude.ai/code/session_01L6MwpMDutv3gtXnnA47mhE