### PR TITLE
Add user deletion functionality to admin panel

### DIFF
--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -83,6 +83,14 @@ export async function deleteUserByEmail(email: User["email"]) {
   return prisma.user.delete({ where: { email } });
 }
 
+export async function deleteUser(id: User["id"]) {
+  return prisma.user.delete({ where: { id } });
+}
+
+export async function deleteInactiveUsers() {
+  return prisma.user.deleteMany({ where: { isActive: false } });
+}
+
 export async function verifyLogin(
   email: User["email"],
   password: Password["hash"]

--- a/app/routes/users/$userId.edit.tsx
+++ b/app/routes/users/$userId.edit.tsx
@@ -22,7 +22,7 @@ export const action: ActionFunction = async ({ request }) => {
   const uploadHandler = unstable_composeUploadHandlers(
     async ({ name, data, filename }) => {
       if (name !== "avatar" || !filename) {
-        // Let the memory handler capture text fields (id/email/password/etc.)
+        // Let the memory handler capture text fields (email/password/etc.)
         return undefined;
       }
       const uploadedImage = await uploadImage(data, "avatars").catch((err) =>

--- a/app/routes/users/index.tsx
+++ b/app/routes/users/index.tsx
@@ -5,6 +5,8 @@ import type { User } from "~/models/user.server";
 import {
   activateUser,
   deactivateUser,
+  deleteInactiveUsers,
+  deleteUser,
   getActiveUsers,
   getInactiveUsers,
   getUserById,
@@ -42,9 +44,25 @@ export const action: ActionFunction = async ({ request }) => {
   await requireActiveUser(request);
   const formData = await request.formData();
   const action = formData.get("_action");
+
+  if (typeof action !== "string") {
+    return json<ActionData>(
+      { formError: "Form was not submitted correctly." },
+      { status: 400 }
+    );
+  }
+
+  if (action === "deleteAllPending") {
+    const { count } = await deleteInactiveUsers();
+    const response = `${count} pending ${
+      count === 1 ? "user was" : "users were"
+    } deleted.`;
+    return json<ActionData>({ response });
+  }
+
   const userId = formData.get("userId");
 
-  if (typeof action !== "string" || typeof userId !== "string") {
+  if (typeof userId !== "string") {
     return json<ActionData>(
       { formError: "Form was not submitted correctly." },
       { status: 400 }
@@ -59,6 +77,8 @@ export const action: ActionFunction = async ({ request }) => {
     return json<ActionData>({ errors, fields }, { status: 400 });
   }
 
+  const user = await getUserById(userId);
+
   switch (action) {
     case "deactivate": {
       await deactivateUser(userId);
@@ -68,9 +88,13 @@ export const action: ActionFunction = async ({ request }) => {
       await activateUser(userId);
       break;
     }
+    case "delete": {
+      await deleteUser(userId);
+      return json<ActionData>({
+        response: `${user?.username} was deleted.`,
+      });
+    }
   }
-
-  const user = await getUserById(userId);
 
   const response = `${user?.username} was updated.`;
 
@@ -151,7 +175,32 @@ export default function UserIndex() {
         </table>
       </div>
       <div>
-        <h1>Pending Users</h1>
+        <div className="flex items-center justify-between">
+          <h1>Pending Users</h1>
+          {inactiveUsers.length > 0 && (
+            <Form
+              method="post"
+              onSubmit={(event) => {
+                if (
+                  !window.confirm(
+                    "Delete all pending users? This cannot be undone."
+                  )
+                ) {
+                  event.preventDefault();
+                }
+              }}
+            >
+              <button
+                className="btn btn-error"
+                type="submit"
+                name="_action"
+                value="deleteAllPending"
+              >
+                Clear All Pending
+              </button>
+            </Form>
+          )}
+        </div>
         <table className="table-zebra table w-full">
           <thead>
             <tr>
@@ -166,7 +215,7 @@ export default function UserIndex() {
                   <Link to={`${user.id}`}>{user.username}</Link>
                 </td>
                 <td className="text-right">
-                  <Form method="post">
+                  <Form className="inline" method="post">
                     <input type="hidden" name="userId" value={user.id} />
                     <button
                       className="btn btn-primary"
@@ -175,6 +224,29 @@ export default function UserIndex() {
                       value="activate"
                     >
                       Activate
+                    </button>
+                  </Form>
+                  <Form
+                    className="ml-4 inline"
+                    method="post"
+                    onSubmit={(event) => {
+                      if (
+                        !window.confirm(
+                          `Delete ${user.username}? This cannot be undone.`
+                        )
+                      ) {
+                        event.preventDefault();
+                      }
+                    }}
+                  >
+                    <input type="hidden" name="userId" value={user.id} />
+                    <button
+                      className="btn btn-error"
+                      type="submit"
+                      name="_action"
+                      value="delete"
+                    >
+                      Delete
                     </button>
                   </Form>
                 </td>

--- a/app/routes/users/index.tsx
+++ b/app/routes/users/index.tsx
@@ -66,7 +66,7 @@ export const action: ActionFunction = async ({ request }) => {
 
   if (!user) {
     return json<ActionData>(
-      { errors: { userId: "User not found" }, fields: { action, userId } },
+      { errors: { userId: "User not found" }, fields: { _action: action, userId } },
       { status: 400 }
     );
   }

--- a/app/routes/users/index.tsx
+++ b/app/routes/users/index.tsx
@@ -33,13 +33,6 @@ type LoaderData = {
   inactiveUsers: User[];
 };
 
-async function validateUserId(userId: string) {
-  const user = await getUserById(userId);
-  if (!user) {
-    return "User not found";
-  }
-}
-
 export const action: ActionFunction = async ({ request }) => {
   await requireActiveUser(request);
   const formData = await request.formData();
@@ -69,15 +62,14 @@ export const action: ActionFunction = async ({ request }) => {
     );
   }
 
-  const errors = {
-    userId: await validateUserId(userId),
-  };
-  const fields = { action, userId };
-  if (Object.values(errors).some(Boolean)) {
-    return json<ActionData>({ errors, fields }, { status: 400 });
-  }
-
   const user = await getUserById(userId);
+
+  if (!user) {
+    return json<ActionData>(
+      { errors: { userId: "User not found" }, fields: { action, userId } },
+      { status: 400 }
+    );
+  }
 
   switch (action) {
     case "deactivate": {
@@ -89,14 +81,24 @@ export const action: ActionFunction = async ({ request }) => {
       break;
     }
     case "delete": {
-      await deleteUser(userId);
+      if (user.isActive) {
+        return json<ActionData>(
+          { formError: "Only pending users can be deleted." },
+          { status: 400 }
+        );
+      }
+      try {
+        await deleteUser(userId);
+      } catch {
+        // User was already removed (e.g. a concurrent delete); nothing to do.
+      }
       return json<ActionData>({
-        response: `${user?.username} was deleted.`,
+        response: `${user.username} was deleted.`,
       });
     }
   }
 
-  const response = `${user?.username} was updated.`;
+  const response = `${user.username} was updated.`;
 
   return json<ActionData>({ response });
 };


### PR DESCRIPTION
## Summary
This PR adds the ability for administrators to delete inactive (pending) users from the system. It includes both individual user deletion and bulk deletion of all pending users, with appropriate confirmation dialogs and validation.

## Key Changes
- **New deletion functions** in `user.server.ts`:
  - `deleteUser(id)` - Delete a single user by ID
  - `deleteInactiveUsers()` - Delete all inactive users at once

- **Enhanced action handler** in `users/index.tsx`:
  - Added validation for the `_action` parameter before processing
  - Implemented `deleteAllPending` action to bulk delete all pending users
  - Implemented `delete` action for individual user deletion with validation (only allows deletion of inactive users)
  - Improved error handling with try-catch for concurrent delete scenarios
  - Refactored `validateUserId` logic inline for better control flow

- **UI improvements** in `users/index.tsx`:
  - Added "Clear All Pending" button in the Pending Users section header (only visible when pending users exist)
  - Added individual "Delete" button for each pending user in the table
  - Added confirmation dialogs for both bulk and individual deletions
  - Adjusted button styling with proper spacing and error button styling

- **Minor cleanup**:
  - Updated comment in `$userId.edit.tsx` to remove outdated reference

## Implementation Details
- Deletion is restricted to inactive users only; attempting to delete active users returns a 400 error
- Concurrent deletion attempts are handled gracefully with a try-catch block
- User confirmation is required before any deletion action via browser dialog
- Response messages provide feedback on successful deletions with proper pluralization

https://claude.ai/code/session_01GaKgbbTxCgUghF2fWzg7JP